### PR TITLE
update tools/make folder and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ _Returns the program hash of the main program (chunk_processor.cairo)_
 make get-program-hash
 ```
 
+For more details about the commands, see [tools/make/README.md](tools/make/README.md).
+
 #### One chunk simulated usage :
 
 1. Modify the last line of `tools/make/prepare_inputs_api.py` to choose the start block number and batch size.

--- a/tools/make/README.md
+++ b/tools/make/README.md
@@ -1,0 +1,87 @@
+# Utility Scripts
+
+
+## `setup.sh`
+### Usage : `make setup`
+
+This script sets up a virtual environment within the venv/ directory and installs all the necessary Python packages. Additionally, it updates the environment variable PYTHONPATH to ensure Python scripts within the tools/ directory can be executed from any location.
+
+
+## `build.sh`
+
+### Usage : `make build`
+
+This script compiles all Cairo files located in:
+- `src/`
+- `tests/cairo_programs/`
+
+The compiled outputs are stored in `build/compiled_cairo_files/`.
+
+## `launch_cairo_files.py`
+
+### Usage : `make run` or `make run-profile`
+
+This script provides an option to choose a Cairo file for execution from:
+- `src/single_chunk_processor/chunk_processor.cairo`  
+- All the Cairo files within  `tests/cairo_programs/`
+
+After selection, the script compiles the chosen file and runs it, using input from a corresponding file located in the same directory. The input file should have the same name as the Cairo file but with the `_input.json` extension in place of `.cairo.`
+
+For the `chunk_processor.cairo` file, an additional prompt allows selection from input files ending in `_input.json` within the `src/single_chunk_processor/data` directory.
+
+
+If `make-run-profile` is chosen, the Cairo file is executed with profiling enabled. The resultant profile graph is saved to `build/profiling/`.
+
+## `prepare_inputs_api.py`
+
+### Usage : `make prepare-processor-input`
+
+This Python script prepares inputs for the chunk processor and precomputes the expected outputs. To specify which inputs to prepare, modify the main function at the end of this file.
+
+The `prepare_full_chain_inputs` function parameters include:
+
+ - `from_block_number_high` : Highest block number to include in the input  
+ - `to_block_number_low` : Lowest block number to include in the input
+ - `batch_size` : Number of blocks to include in each batch
+ - (Optional) `initial_peaks` : A dictionary containing the lists of initial peaks (from left to right) for both the Poseidon and Keccak MMR. If not specified, the initial peaks are the following :
+```JSON
+{
+    "poseidon": [968420142673072399148736368629862114747721166432438466378474074601992041181],
+    "keccak": [93435818137180840214006077901347441834554899062844693462640230920378475721064]
+}
+```  
+ These values correspond to the Poseidon and Keccak hashes of the string `b'brave new world'`. They are the initial peaks of the MMRs used by the chunk processor.
+
+ - (Optional) `initial_mmr_size` : The initial size of the MMR. If not specified, the initial size is 1.
+
+  - (Optional) `initial_mmr_root` : The initial root of both the Poseidon and Keccak MMR. If not specified, they correspond to the initial peaks : 
+```JSON
+{
+    "poseidon": 968420142673072399148736368629862114747721166432438466378474074601992041181, 
+    "keccak": 93435818137180840214006077901347441834554899062844693462640230920378475721064
+}
+```
+
+The primary operations of this function are: 
+ 1. Splitting blocks to process into batches of size `batch_size`, except for the last batch which can be smaller.
+ 2. Fetching the block data for each chunk from the RPC node provided in the .env file at the root of the repository.
+ 3. Using an internal Rust API to compute the expected output for each chunk, which simulates the chunk processor's actions.
+ 4. Writing the inputs and expected outputs to src/single_chunk_processor/data/. Those can be used later by the chunk processor and the script `sharp_submit.py`.
+
+
+
+
+
+## `sharp_submit.py`
+
+### Usages :
+1) `make batch-cairo-pie`:  
+    Runs the chunk processor on all the inputs files under `src/single_chunk_processor/data/` and create PIE objects for each of them in the same directory.
+    It also checks that the output of each run matches the precomputed output in the same directory.
+2) `make batch-sharp-submit`:  
+    Submits all the PIE objects under `src/single_chunk_processor/data/` to SHARP. Results, including job keys and facts, are saved to  `src/single_chunk_processor/data/sharp_submit_results.json`.
+3) `make batch-run-and-submit`:  
+    Combines the processes of 1) and 2) into a single command.
+
+
+

--- a/tools/make/requirements.txt
+++ b/tools/make/requirements.txt
@@ -1,7 +1,6 @@
 cairo-lang
-blake3
-tinydb
 typeguard==2.13.3
 protobuf==3.20.3
 inquirer
 python-dotenv
+pysha3

--- a/tools/make/setup.sh
+++ b/tools/make/setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-system=$(uname)
-
 python3.9 -m venv venv
 echo 'export PYTHONPATH="$PWD:$PYTHONPATH"' >> venv/bin/activate
 source venv/bin/activate

--- a/tools/make/sharp_submit.py
+++ b/tools/make/sharp_submit.py
@@ -4,6 +4,7 @@ import subprocess
 import argparse
 import json
 
+STARK_PRIME = 3618502788666131213697322783095070105623107215331596699973092056135872020481
 def write_to_json(filename, data):
     """Helper function to write data to a json file"""
     with open(filename, 'w') as f:
@@ -11,7 +12,7 @@ def write_to_json(filename, data):
 
 
 # Create an ArgumentParser object
-parser = argparse.ArgumentParser(description="A simple script to demonstrate argparse")
+parser = argparse.ArgumentParser(description="A tool for submitting pie objects to SHARP.")
 
 # Define command-line arguments
 parser.add_argument("-pie", action="store_true", help="create pie objects")
@@ -42,22 +43,72 @@ PROGRAM_HASH = int(subprocess.check_output(["cairo-hash-program", "--program", f
 input_files=[f for f in os.listdir(INPUT_PATH) if f.endswith("_input.json")]
 input_files_paths=[INPUT_PATH+f for f in input_files]
 
-def run_cairo_program(input_file_path):
-    """Run cairo program and return the output."""
+CAIROUT_OUTPUT_KEYS = [
+        "from_block_number_high",
+        "to_block_number_low",
+        "block_n_plus_one_parent_hash_low",
+        "block_n_plus_one_parent_hash_high",
+        "block_n_minus_r_plus_one_parent_hash_low",
+        "block_n_minus_r_plus_one_parent_hash_high",
+        "mmr_last_root_poseidon",
+        "mmr_last_root_keccak_low",
+        "mmr_last_root_keccak_high",
+        "mmr_last_len",
+        "new_mmr_root_poseidon",
+        "new_mmr_root_keccak_low",
+        "new_mmr_root_keccak_high",
+        "new_mmr_len"
+    ]
+
+
+def run_cairo_program(input_file_path) -> dict:
+    """
+    Run the cairo program on the given input file and return the program's output
+    as a dictionary.
+    Write the pie object to a file named <input_filename>_pie.zip to the same directory as the input file.
+    """
     input_name = input_file_path.split('/')[-1].split('.')[0].removesuffix('_input')
-    cmd=f"cairo-run --program={COMPILED_CAIRO_FILE_PATH} --program_input={input_file_path} --layout=starknet_with_keccak"
+    cmd=f"cairo-run --program={COMPILED_CAIRO_FILE_PATH} --program_input={input_file_path} --layout=starknet_with_keccak --print_output"
     cmd+=f" --cairo_pie_output {INPUT_PATH}{input_name}_pie.zip"
-    os.system(cmd)
+    stream = os.popen(cmd)
+    output = stream.read()
+
+    return parse_cairo_output(output)
+
+def parse_cairo_output(output: str) -> dict:
+    """
+    Parse the output of the cairo program from stdout and return it as a dictionary.
+    """
+    lines = output.split("\n")
+    program_output_index = lines.index("Program output:")
+    # Extract field elements from the lines after 'Program output:'
+    
+    felts = []
+    for line in lines[program_output_index + 1:]:
+        line = line.strip()
+        try:
+            num = int(line)
+            felts.append(num % STARK_PRIME)
+        except ValueError:
+            # If a line cannot be converted to an integer, skip it.
+            continue
+
+    assert len(felts) == len(CAIROUT_OUTPUT_KEYS), f"Expected {len(CAIROUT_OUTPUT_KEYS)} numbers in output, got {len(felts)}"
+    return dict(zip(CAIROUT_OUTPUT_KEYS, felts))
+
 
 def submit_pie_to_sharp(filename):
+    """Submit a pie object to SHARP and return the job key and fact"""
     result = subprocess.run(
         ["cairo-sharp", "submit", "--cairo_pie", f"{INPUT_PATH}{filename.removesuffix('_input.json')}_pie.zip"], 
         text=True,
         capture_output=True
     )
+    if result.returncode != 0:
+        raise Exception(f"Failed to submit pie to SHARP: {result.stderr}")
+    
     # Extract Job Key and Fact from stdout
-    job_key = None
-    fact = None
+    job_key, fact = None, None
     for line in result.stdout.splitlines():
         if 'Job key:' in line:
             job_key = line.split(':')[-1].strip()
@@ -65,28 +116,39 @@ def submit_pie_to_sharp(filename):
             fact = line.split(':')[-1].strip()
 
     if job_key is None or fact is None:
-        raise Exception(f"Failed to submit pie to SHARP: {result.stdout}")
+        raise Exception(f"Failed to parse job key and fact from SHARP output: {result.stdout}")
     
     return job_key, fact
 
 
+if __name__ == "__main__":
+    sharp_results = {}
+    for input_filename, input_filepath in zip(input_files, input_files_paths):
 
-results = {}
-for filename, filepath in zip(input_files, input_files_paths):
+        if args.pie:
+            print(f'Running chunk processor for {input_filename} ...') 
+            output = run_cairo_program(input_filepath)
+            expected_output = json.load(open(input_filepath.replace('_input', '_output')))
+            assert output == expected_output, f"Output mismatch for {input_filename}.Expected: \n {expected_output}\n got: \n{output}"
+            print(f"\t ==> Run successful. Output matches precomputed output.")
+            print(f"\t ==> PIE Object written to {INPUT_PATH}{input_filename.removesuffix('_input.json')}_pie.zip \n")
+
+
+        if args.sharp:
+            print(f"Submitting job for {input_filename} to SHARP ...")
+            
+            job_key, fact = submit_pie_to_sharp(input_filename)
+            print(f"\t ==> Job submitted successfully to SHARP.")
+            print(f"\t ==> Job key: {job_key}, Fact: {fact} \n")
+
+            sharp_results[input_filename] = {'job_key': job_key, 'fact': fact}
+            
+            write_to_json(f"{INPUT_PATH}sharp_submit_results.json", sharp_results)
+    
 
     if args.pie:
-        print('Running program and preparing cairo PIE object...')
-        print(filename)
-        run_cairo_program(filepath)
-        print('Done.')
-
-
+        print(f"All runs successful. PIE objects written to {INPUT_PATH}")
     if args.sharp:
-        print(f"Submitting job for {filename} to SHARP")
-
-        job_key, fact = submit_pie_to_sharp(filename)
-        results[filename] = {'job_key': job_key, 'fact': fact}
-        
-        write_to_json(f"{INPUT_PATH}sharp_submit_results.json", results)
+        print(f"All jobs submitted successfully. Results written to {INPUT_PATH}sharp_submit_results.json")
 
 

--- a/tools/py/utils.py
+++ b/tools/py/utils.py
@@ -1,0 +1,22 @@
+def split_128(a):
+    """Takes in value, returns uint256-ish tuple."""
+    return (a & ((1 << 128) - 1), a >> 128)
+
+
+def bytes_to_little_endian_ints(input_bytes):
+    # Split the input_bytes into 8-byte chunks
+    byte_chunks = [input_bytes[i:i + 8] for i in range(0, len(input_bytes), 8)]
+
+    # Convert each chunk to little-endian integers
+    little_endian_ints = [int.from_bytes(chunk, byteorder='little') for chunk in byte_chunks]
+
+    return little_endian_ints
+
+def bytes_to_8_bytes_chunks(input_bytes):
+    # Split the input_bytes into 8-byte chunks
+    byte_chunks = [input_bytes[i:i + 8] for i in range(0, len(input_bytes), 8)]
+
+    # Convert each chunk to little-endian integers
+    little_endian_ints = [int.from_bytes(chunk, byteorder='big') for chunk in byte_chunks]
+
+    return little_endian_ints


### PR DESCRIPTION
 - `launch_cairo_files `: remove unused dependencies and code
- `prepare_inputs_api` : import `split_128 `from `tools.py.utils`, better verbose and input checks 
- `requirements.txt`: remove unused `blake3/tinydb`. Adds `pysha3` as it used in some cairo programs tests
- `setup.sh `: remove unused system name
- `sharp_submit` : Parses the output of each `cairo-run` from stdout and assert it matches the precomputed outputs by `prepare_inputs_api`. This makes testing automatic and easier by just running `make batch-cairo-pie` instead of manually inspecting the new roots. 
Better error management. Better verbose. 
- `Readme`: Added documenation on all the make scripts. 
- `Main Readme` : added link to Readme of make scripts